### PR TITLE
Revert "Deploy mercator related changes"

### DIFF
--- a/bay-services/worker.yaml
+++ b/bay-services/worker.yaml
@@ -1,6 +1,6 @@
 services:
 - &worker_def
-  hash: 983db55b04ff7bef65cd09cb19d851933c03e0f7
+  hash: dc415a87cfb5212ded0066e3a001799811f01a4a
   hash_length: 7
   name: worker-ingestion
   environments:


### PR DESCRIPTION
This reverts commit c9c489697062c906bc9b420df516ea07317aa29c.

See https://github.com/fabric8-analytics/fabric8-analytics-worker/issues/334 for reason