### PR TITLE
Create osd-monitor-poc.yaml

### DIFF
--- a/bay-services/osd-monitor-poc.yaml
+++ b/bay-services/osd-monitor-poc.yaml
@@ -1,0 +1,6 @@
+services:
+- hash: d69514b569bcff2e1a45804c545ac2b879b372b7
+  name: osd-monitor-poc
+  path: /bayesian-monitor.yml
+  url: https://github.com/redhat-developer/osd-monitor-poc/
+  hash_length: 6


### PR DESCRIPTION
A near twin of the normal saas-openshiftio osd-monitor-poc.yaml, this one pulls out the /bayesian-monitor.yml template.