### PR TITLE
Less priority workers (4->1) and more ingestion workers (15->18)

### DIFF
--- a/bay-services/worker-scaler.yaml
+++ b/bay-services/worker-scaler.yaml
@@ -6,7 +6,7 @@ services:
   - name: production
     parameters:
       DEFAULT_REPLICAS: 5
-      MAX_REPLICAS: 15
+      MAX_REPLICAS: 18
       DC_NAME: bayesian-worker-ingestion
       SQS_QUEUE_NAME: ingestion_bayesianFlow_v0,ingestion_bayesianPackageFlow_v0
       OC_PROJECT: bayesian-production

--- a/bay-services/worker.yaml
+++ b/bay-services/worker.yaml
@@ -48,7 +48,7 @@ services:
     parameters:
       WORKER_ADMINISTRATION_REGION: priority
       WORKER_EXCLUDE_QUEUES: GraphImporterTask
-      REPLICAS: 4
+      REPLICAS: 1
   - name: staging
     parameters:
       WORKER_ADMINISTRATION_REGION: priority


### PR DESCRIPTION
Priority and ingestion workers have the same cpu/mem requests and limits. So we are just reallocating resources from one type of worker to another.