### PR TITLE
[bay-services/worker.yaml] fix copy-pasta error

### DIFF
--- a/bay-services/worker.yaml
+++ b/bay-services/worker.yaml
@@ -139,7 +139,7 @@ services:
     parameters:
       WORKER_ADMINISTRATION_REGION: ingestion
       WORKER_NAME_SUFFIX: '-dispatcher'
-      MEMORY_LIMIT: 256Mi
+      MEMORY_REQUEST: 256Mi
       MEMORY_LIMIT: 320Mi
       CPU_REQUEST: 200m
       CPU_LIMIT: 350m


### PR DESCRIPTION
From [e2e-test/896](https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/896/console):

```
The DeploymentConfig "bayesian-worker-ingestion-dispatcher" is invalid:
spec.template.spec.containers[0].resources.limits: Invalid value: "320Mi":
must be greater than or equal to memory request
```