### PR TITLE
Add config for NPM recommender on staging

### DIFF
--- a/bay-services/f8a-chester.yaml
+++ b/bay-services/f8a-chester.yaml
@@ -1,0 +1,13 @@
+services:
+- hash:
+  hash_length: 7
+  name: f8a-chester
+  environments:
+  - name: staging
+    parameters:
+      REPLICAS: 1
+      CPU_REQUEST: 0.30
+      CPU_LIMIT: 0.30
+      FLASK_LOGGING_LEVEL: DEBUG
+  path: /openshift/template.yaml
+  url: https://github.com/fabric8-analytics/fabric8-analytics-npm-insights/


### PR DESCRIPTION
Since we have not got a go-ahead from the SD team I only added a config
for staging, I'm assuming this automatically __does not__ bring up any
services/pods in production.

Signed-off-by: Avishkar Gupta <avgupta@redhat.com>