### PR TITLE
Fix empty hash in f8a-chester template

### DIFF
--- a/bay-services/f8a-chester.yaml
+++ b/bay-services/f8a-chester.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 8eb7ee9aa81c1f384b8db8597c758c52cf812790
+- hash: none
   hash_length: 7
   name: f8a-chester
   environments:

--- a/bay-services/f8a-chester.yaml
+++ b/bay-services/f8a-chester.yaml
@@ -1,11 +1,10 @@
 services:
-- hash:
+- hash: 8eb7ee9aa81c1f384b8db8597c758c52cf812790
   hash_length: 7
   name: f8a-chester
   environments:
   - name: staging
     parameters:
-      REPLICAS: 1
       CPU_REQUEST: 0.30
       CPU_LIMIT: 0.30
       FLASK_LOGGING_LEVEL: DEBUG


### PR DESCRIPTION
The end to end tests when merging to master for this service are failing after the first time, the source of the problem looks to be this linke from the logs `+ NEW_DC_REVISION=1
` (https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/998/console). I figured this is the solution for that.

Also there's this error message: `error: unknown parameter name "REPLICAS"` so removing that parameter.