### PR TITLE
Generate requirements.txt through pip-compile

### DIFF
--- a/bay-services/api-backbone.yaml
+++ b/bay-services/api-backbone.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 150509c6397a2bf19e7d1630300959d2887336ae
+- hash: 250d0d653f205977c0b6565c13f0550d2a746085
   hash_length: 7
   name: api-backbone 
   environments:

--- a/bay-services/kronos.yaml
+++ b/bay-services/kronos.yaml
@@ -1,6 +1,6 @@
 services:
 - &kronos_def
-  hash: 3fba04e9c31f44074db7c9bb33b994d22377188a
+  hash: 3600ad1b10ec1b64f42be1eb2eb0b39650299c4d
   hash_length: 7
   name: kronos-pypi
   environments:

--- a/bay-services/license-analysis.yaml
+++ b/bay-services/license-analysis.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 2ee4f0986dcc79f5a7628d481ff2f2f4de830cbe
+- hash: 254e67ccb7e35107fafa6f41bc2fb418d0c55553
   hash_length: 7
   name: license-analysis
   path: /openshift/template.yaml

--- a/bay-services/worker-scaler.yaml
+++ b/bay-services/worker-scaler.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: a32f18a53deae3b002d61db0843dc1960bd93dbc
+- hash: 9f3d9230c2c96f47ad23c670be25e63b71035685
   hash_length: 7
   name: worker-scaler
   environments:


### PR DESCRIPTION
Fixes all the analytics repositories to have requirements.txt generated through `pip-compile`.