### PR TITLE
Change deployment name for analytics insights service

### DIFF
--- a/bay-services/f8a-npm-insights.yaml
+++ b/bay-services/f8a-npm-insights.yaml
@@ -1,7 +1,7 @@
 services:
 - hash: none
   hash_length: 7
-  name: f8a-chester
+  name: f8a-npm-insights
   environments:
   - name: staging
     parameters:


### PR DESCRIPTION
As per the [discussion on housekeeping](https://gitlab.cee.redhat.com/dtsd/housekeeping/issues/1723) introducing these changes to ensure naming consistency across the repo/image/deployment names changing the DC name and deployment units.

Signed-off-by: Avishkar Gupta <avgupta@redhat.com>