### PR TITLE
Deploy RHEL f8a-server in staging

### DIFF
--- a/bay-services/api.yaml
+++ b/bay-services/api.yaml
@@ -6,6 +6,7 @@ services:
   - name: staging
     parameters:
       FLASK_LOGGING_LEVEL: DEBUG
+      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
   - name: production
     parameters:
       FLASK_LOGGING_LEVEL: DEBUG


### PR DESCRIPTION
As part of an effort to migrate the services running in OSIO from CentOS
to RHEL, we are ready to push out the RHEL based image for this service
into staging.