### PR TITLE
enable gremlin RHEL based images on prod-preview

### DIFF
--- a/bay-services/gremlin.yaml
+++ b/bay-services/gremlin.yaml
@@ -14,7 +14,7 @@ services:
       CHANNELIZER: http
       REST_VALUE: 1
       REPLICAS: 1
-      DOCKER_REGISTRY: push.registry.devshift.net/osio-prod
+      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/
 
@@ -33,6 +33,6 @@ services:
       QUERY_ADMINISTRATION_REGION: ingestion
       REST_VALUE: 1
       REPLICAS: 1
-      DOCKER_REGISTRY: push.registry.devshift.net/osio-prod
+      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/

--- a/bay-services/gremlin.yaml
+++ b/bay-services/gremlin.yaml
@@ -14,6 +14,7 @@ services:
       CHANNELIZER: http
       REST_VALUE: 1
       REPLICAS: 1
+      DOCKER_REGISTRY: push.registry.devshift.net/osio-prod
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/
 
@@ -32,5 +33,6 @@ services:
       QUERY_ADMINISTRATION_REGION: ingestion
       REST_VALUE: 1
       REPLICAS: 1
+      DOCKER_REGISTRY: push.registry.devshift.net/osio-prod
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/


### PR DESCRIPTION
enable gremlin RHEL based images on prod-preview
related to: 
- https://github.com/fabric8-analytics/gremlin-docker/pull/34 
- https://github.com/openshiftio/openshiftio-cico-jobs/pull/628

