### PR TITLE
enable f8a-server-backbone RHEL based image of on prod-preview

### DIFF
--- a/bay-services/api-backbone.yaml
+++ b/bay-services/api-backbone.yaml
@@ -14,5 +14,6 @@ services:
       CPU_REQUEST: 0.25
       CPU_LIMIT: 1
       FLASK_LOGGING_LEVEL: DEBUG
+      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/f8a-server-backbone/ 


### PR DESCRIPTION
enable f8a-server-backbone RHEL based image of on prod-preview
related to: 
- https://github.com/fabric8-analytics/f8a-server-backbone/pull/77
- https://github.com/openshiftio/openshiftio-cico-jobs/pull/629

cc: @tisnik @jmelis 