### PR TITLE
enable gemini RHEL based image on prod-preview

### DIFF
--- a/bay-services/gemini.yaml
+++ b/bay-services/gemini.yaml
@@ -13,5 +13,6 @@ services:
   - name: staging
     parameters:
       REPLICAS: 1
+      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/fabric8-gemini-server/


### PR DESCRIPTION
enable gemini RHEL based image on prod-preview

cc: @abs51295 