### PR TITLE
enable firehose-fetcher RHEL based image on prod-preview

### DIFF
--- a/bay-services/firehose-fetcher.yaml
+++ b/bay-services/firehose-fetcher.yaml
@@ -9,5 +9,6 @@ services:
   - name: staging
     parameters:
       ENABLE_SCHEDULING: 0
+      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/fabric8-analytics-firehose-fetcher


### PR DESCRIPTION
enable firehose-fetcher RHEL based image on prod-preview
depends on: https://github.com/fabric8-analytics/fabric8-analytics-firehose-fetcher/pull/25 -- merged