### PR TITLE
promote rhel based worker-scaler service to preview

### DIFF
--- a/bay-services/worker-scaler.yaml
+++ b/bay-services/worker-scaler.yaml
@@ -19,5 +19,6 @@ services:
       SQS_QUEUE_NAME: ingestion_bayesianFlow_v0,ingestion_bayesianPackageFlow_v0
       OC_PROJECT: bayesian-preview
       DRY_RUN: false
+      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/fabric8-analytics-scaler/


### PR DESCRIPTION
promote rhel based worker-scaler service to preview
should be merged after build master / e2e test jobs will success https://ci.centos.org/job/devtools-fabric8-analytics-scaler-f8a-build-master/35/console