### PR TITLE
promote rhel based stack-report-ui to preview

### DIFF
--- a/bay-services/stack-report-ui.yaml
+++ b/bay-services/stack-report-ui.yaml
@@ -2,5 +2,9 @@ services:
 - hash: 045d4ea43356ee72b7a0db451705f5dd82accfd6
   hash_length: 7
   name: stack-report-ui
+  environments:
+  - name: staging
+    parameters:
+      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/fabric8-analytics-stack-report-ui/


### PR DESCRIPTION
promote rhel based stack-report-ui to preview
to merge this we have to wait green job here https://ci.centos.org/job/devtools-fabric8-analytics-stack-report-ui-f8a-build-master/