### PR TITLE
Promote rhel based worker-scaler to prod

### DIFF
--- a/bay-services/worker-scaler.yaml
+++ b/bay-services/worker-scaler.yaml
@@ -11,6 +11,7 @@ services:
       SQS_QUEUE_NAME: ingestion_bayesianFlow_v0,ingestion_bayesianPackageFlow_v0
       OC_PROJECT: bayesian-production
       DRY_RUN: false
+      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
   - name: staging
     parameters:
       DEFAULT_REPLICAS: 1


### PR DESCRIPTION
This commit has been previously reverted because the deployment failed in prod.
The issue has been solved (the serviceAccount now has the necessary secret to
pull the image), so this can be reapplied.