### PR TITLE
f8a-server pulling from quay for staging

### DIFF
--- a/bay-services/api.yaml
+++ b/bay-services/api.yaml
@@ -6,7 +6,8 @@ services:
   - name: staging
     parameters:
       FLASK_LOGGING_LEVEL: DEBUG
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-bayesian-bayesian-api
   - name: production
     parameters:
       FLASK_LOGGING_LEVEL: DEBUG


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO build scripts push to Quay. Merge the project's repo PR only after merging this one.