### PR TITLE
f8a-backbone pulling from quay for staging

### DIFF
--- a/bay-services/api-backbone.yaml
+++ b/bay-services/api-backbone.yaml
@@ -1,7 +1,7 @@
 services:
 - hash: 779e67cd4a446f1136eb2f6292fac69927aec4f8
   hash_length: 7
-  name: api-backbone 
+  name: api-backbone
   environments:
   - name: production
     parameters:
@@ -15,6 +15,7 @@ services:
       CPU_REQUEST: 0.25
       CPU_LIMIT: 1
       FLASK_LOGGING_LEVEL: DEBUG
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-server-backbone
   path: /openshift/template.yaml
-  url: https://github.com/fabric8-analytics/f8a-server-backbone/ 
+  url: https://github.com/fabric8-analytics/f8a-server-backbone/


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO build scripts push to Quay. Merge the project's repo PR only after merging this one.