### PR TITLE
f8a-firehose pulling from quay for staging

### DIFF
--- a/bay-services/firehose-fetcher.yaml
+++ b/bay-services/firehose-fetcher.yaml
@@ -7,9 +7,11 @@ services:
     parameters:
       ENABLE_SCHEDULING: 1
       DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_IMAGE: fabric8-analytics/f8a-firehose-fetcher
   - name: staging
     parameters:
       ENABLE_SCHEDULING: 0
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-firehose-fetcher
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/fabric8-analytics-firehose-fetcher


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO build scripts push to Quay. Merge the project's repo PR only after merging this one.