### PR TITLE
f8a-npm-insights pulling from quay for staging

### DIFF
--- a/bay-services/f8a-npm-insights.yaml
+++ b/bay-services/f8a-npm-insights.yaml
@@ -8,7 +8,8 @@ services:
       CPU_REQUEST: 0.30
       CPU_LIMIT: 0.30
       FLASK_LOGGING_LEVEL: DEBUG
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-npm-insights
   - name: production
     parameters:
       CPU_REQUEST: 0.30
@@ -16,5 +17,6 @@ services:
       MEMORY_REQUEST: 1Gi
       MEMORY_LIMIT: 1Gi
       DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_IMAGE: fabric8-analytics/f8a-npm-insights
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/fabric8-analytics-npm-insights/


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO build scripts push to Quay. Merge the project's repo PR only after merging this one.