### PR TITLE
f8a-pgbouncer pulling from quay for staging

### DIFF
--- a/bay-services/pgbouncer.yaml
+++ b/bay-services/pgbouncer.yaml
@@ -6,8 +6,10 @@ services:
   - name: production
     parameters:
       DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_IMAGE: bayesian/coreapi-pgbouncer
   - name: staging
     parameters:
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: rhel-bayesian-coreapi-pgbouncer
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/fabric8-analytics-pgbouncer/


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO build scripts push to Quay. Merge the project's repo PR only after merging this one.