### PR TITLE
f8a-gremlin docker pulling from quay for staging

### DIFF
--- a/bay-services/gremlin.yaml
+++ b/bay-services/gremlin.yaml
@@ -10,12 +10,14 @@ services:
       REST_VALUE: 1
       REPLICAS: 3
       DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_IMAGE: bayesian/gremlin
   - name: staging
     parameters:
       CHANNELIZER: http
       REST_VALUE: 1
       REPLICAS: 1
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/
 
@@ -29,12 +31,14 @@ services:
       REST_VALUE: 1
       REPLICAS: 3
       DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_IMAGE: bayesian/gremlin
   - name: staging
     parameters:
       CHANNELIZER: http
       QUERY_ADMINISTRATION_REGION: ingestion
       REST_VALUE: 1
       REPLICAS: 1
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for
the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build
scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO
build scripts push to Quay. Merge the project's repo PR only after
merging this one.