### PR TITLE
f8a-stack-analysis pulling from quay for staging

### DIFF
--- a/bay-services/kronos.yaml
+++ b/bay-services/kronos.yaml
@@ -11,6 +11,7 @@ services:
       CPU_LIMIT: 2
       REPLICAS: 0
       DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_IMAGE: bayesian/kronos
       RESTART_POLICY: Always
   - name: staging
     parameters:
@@ -18,7 +19,8 @@ services:
       CPU_REQUEST: 1
       CPU_LIMIT: 1
       REPLICAS: 0
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-bayesian-kronos
       RESTART_POLICY: Always
   path: /openshift/template-prod.yaml
   url: https://github.com/fabric8-analytics/fabric8-analytics-stack-analysis/
@@ -35,6 +37,7 @@ services:
       MEMORY_LIMIT: 2048Mi
       REPLICAS: 3
       DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_IMAGE: bayesian/kronos
       RESTART_POLICY: Always
   - name: staging
     parameters:
@@ -44,6 +47,7 @@ services:
       MEMORY_REQUEST: 1024Mi
       MEMORY_LIMIT: 2048Mi
       REPLICAS: 1
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-bayesian-kronos
       RESTART_POLICY: Always
 


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for
the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build
scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO
build scripts push to Quay. Merge the project's repo PR only after
merging this one.