### PR TITLE
f8a-worker-scaler pulling from quay for staging

### DIFF
--- a/bay-services/worker-scaler.yaml
+++ b/bay-services/worker-scaler.yaml
@@ -12,6 +12,7 @@ services:
       OC_PROJECT: bayesian-production
       DRY_RUN: false
       DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_IMAGE: fabric8-analytics/worker-scaler
   - name: staging
     parameters:
       DEFAULT_REPLICAS: 1
@@ -20,6 +21,7 @@ services:
       SQS_QUEUE_NAME: ingestion_bayesianFlow_v0,ingestion_bayesianPackageFlow_v0
       OC_PROJECT: bayesian-preview
       DRY_RUN: false
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-worker-scaler
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/fabric8-analytics-scaler/


### PR DESCRIPTION
Changes the container image to be pulled from Quay. Since this is for
the staging environment, it should not affect production.

Any subsequent PRs to the project's repo will fail unless the CICO build
scripts are pushing the container image to Quay.

A companion PR will be submitted to the project's repo to make the CICO
build scripts push to Quay. Merge the project's repo PR only after
merging this one.