### PR TITLE
Deploy f8a-npm-insights into prod from Quay

### DIFF
--- a/bay-services/f8a-npm-insights.yaml
+++ b/bay-services/f8a-npm-insights.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 9e47013369c732806bb0a5b7e2b47861f381d7c5
+- hash: 2e29ba0b389dcc354484f935a40b7473a69a5a44
   hash_length: 7
   name: f8a-npm-insights
   environments:
@@ -16,7 +16,7 @@ services:
       CPU_LIMIT: 0.30
       MEMORY_REQUEST: 1Gi
       MEMORY_LIMIT: 1Gi
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
-      DOCKER_IMAGE: fabric8-analytics/f8a-npm-insights
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-npm-insights
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/fabric8-analytics-npm-insights/


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.