### PR TITLE
Deploy f8a-gemini-server into prod from Quay

### DIFF
--- a/bay-services/gemini.yaml
+++ b/bay-services/gemini.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 63aa26a251da7a3fc5051e6394e42d1a36fe73f4
+- hash: fcd072e630c178fc86af06eb41e00692d01ab44b
   hash_length: 7
   name: gemini
   environments:
@@ -10,8 +10,8 @@ services:
       CPU_REQUEST: 125m
       CPU_LIMIT: 500m
       REPLICAS: 3
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
-      DOCKER_IMAGE: fabric8-analytics/fabric8-gemini-server
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-fabric8-gemini-server
   - name: staging
     parameters:
       REPLICAS: 1


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.