### PR TITLE
Deploy f8a-3scale-connect-api into prod from Quay

### DIFF
--- a/bay-services/f8a-3scale-connect-api.yaml
+++ b/bay-services/f8a-3scale-connect-api.yaml
@@ -1,12 +1,12 @@
 services:
-- hash: 35a104c22d29e24ae72243a99667f11208a5cb14
+- hash: 8e996bc18f46fd12a422975650e64137cc544513
   hash_length: 7
   name: f8a-3scale-connect-api
   environments:
   - name: production
     parameters:
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
-      DOCKER_IMAGE: fabric8-analytics/f8a-3scale-connect-api
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-3scale-connect-api
   - name: staging
     parameters:
       DOCKER_REGISTRY: quay.io


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.