### PR TITLE
Deploy f8a-firehose-fetcher into prod from Quay

### DIFF
--- a/bay-services/firehose-fetcher.yaml
+++ b/bay-services/firehose-fetcher.yaml
@@ -1,13 +1,13 @@
 services:
-- hash: d94db68fb96303daf08f1dc56e9bc788d12ad5ad
+- hash: 96f8378352b453b35b591e951de80bfadba1aef1
   hash_length: 7
   name: f8a-firehose-fetcher
   environments:
   - name: production
     parameters:
       ENABLE_SCHEDULING: 1
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
-      DOCKER_IMAGE: fabric8-analytics/f8a-firehose-fetcher
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-firehose-fetcher
   - name: staging
     parameters:
       ENABLE_SCHEDULING: 0


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.