### PR TITLE
Deploy f8a-jobs into prod from Quay

### DIFF
--- a/bay-services/jobs.yaml
+++ b/bay-services/jobs.yaml
@@ -1,12 +1,12 @@
 services:
-- hash: d1a83c1e96fa7ccd3c60d41702ad19295fe45b45
+- hash: 4ba5b7130db9fd1152f2227da54cd70db6235f5f
   hash_length: 7
   name: jobs
   environments:
   - name: production
     parameters:
-       DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
-       DOCKER_IMAGE: bayesian/coreapi-jobs
+       DOCKER_REGISTRY: quay.io
+       DOCKER_IMAGE: openshiftio/rhel-bayesian-coreapi-jobs
   - name: staging
     parameters:
        DOCKER_REGISTRY: quay.io


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.