### PR TITLE
Deploy analytics-server into prod from Quay

### DIFF
--- a/bay-services/api.yaml
+++ b/bay-services/api.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 96a4a8b516c4c915a0bcbefb402e1cba4ceb73d1
+- hash: eb44499ab73c48dd4cf9a550b1bbffe87ad31cdd
   hash_length: 7
   name: api
   environments:
@@ -12,6 +12,7 @@ services:
     parameters:
       FLASK_LOGGING_LEVEL: DEBUG
       REPLICAS: 3
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-bayesian-bayesian-api
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/fabric8-analytics-server/


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.