### PR TITLE
Deploy stack-report-ui into prod from Quay

### DIFF
--- a/bay-services/stack-report-ui.yaml
+++ b/bay-services/stack-report-ui.yaml
@@ -1,12 +1,12 @@
 services:
-- hash: b53be9eee6140c9f9622d14368527ae9fd12f180
+- hash: a89ae0ef2c4def92d4d5445ce00719893b427627
   hash_length: 7
   name: stack-report-ui
   environments:
   - name: production
     parameters:
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
-      DOCKER_IMAGE: fabric8-analytics-stack-report-ui
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-stack-report-ui
   - name: staging
     parameters:
       DOCKER_REGISTRY: quay.io


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.