### PR TITLE
Deploy analytics-scaler into prod from Quay

### DIFF
--- a/bay-services/worker-scaler.yaml
+++ b/bay-services/worker-scaler.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 109a5068647a128cc998ddb798274cc6bd19fc9e
+- hash: 713aa7e58b0a2f64485d41aea8106efdc0581c4c
   hash_length: 7
   name: worker-scaler
   environments:
@@ -11,8 +11,8 @@ services:
       SQS_QUEUE_NAME: ingestion_bayesianFlow_v0,ingestion_bayesianPackageFlow_v0
       OC_PROJECT: bayesian-production
       DRY_RUN: false
-      DOCKER_REGISTRY: prod.registry.devshift.net/osio-prod
-      DOCKER_IMAGE: fabric8-analytics/worker-scaler
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-worker-scaler
   - name: staging
     parameters:
       DEFAULT_REPLICAS: 1


### PR DESCRIPTION
Since this project has been deployed succesfully into staging from Quay,
we can now promote to prod.

Note that the images are no longer being pused to the devshift registry,
so if this PR is not merged, please make sure that in the next hash
update you are also updating the image to be pulled from quay, instead
of from the devshift registry.