### PR TITLE
Decrease the sleep period for f8a release monitor

### DIFF
--- a/bay-services/release-monitor.yaml
+++ b/bay-services/release-monitor.yaml
@@ -11,7 +11,7 @@ services:
       REPLICAS: 1
       NPM_URL: https://registry.npmjs.org/
       PYPI_URL: https://pypi.org/
-      SLEEP_INTERVAL: 30
+      SLEEP_INTERVAL: 10
   - name: staging
     parameters:
       ENABLE_SCHEDULING: 0
@@ -20,6 +20,6 @@ services:
       REPLICAS: 1
       NPM_URL: https://registry.npmjs.org/
       PYPI_URL: https://pypi.org/
-      SLEEP_INTERVAL: 30
+      SLEEP_INTERVAL: 10
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/fabric8-analytics-release-monitor


### PR DESCRIPTION
From 30 minutes to 10 minutes.