### PR TITLE
renaming service

### DIFF
--- a/bay-services/fabric8-analytics-bigquery-manifests-job.yaml
+++ b/bay-services/fabric8-analytics-bigquery-manifests-job.yaml
@@ -1,7 +1,7 @@
 services:
 - hash: none
   hash_length: 7
-  name: f8a-bq-manifests-job
+  name: fabric8-analytics-bigquery-manifests-job
   environments:
   - name: staging
     parameters:


### PR DESCRIPTION
Considering saas service is being picked up based on GH repo name, renaming this to maintain consistency.