### PR TITLE
gremlin xmx to 1500mi to not give OOM error

### DIFF
--- a/bay-services/gremlin.yaml
+++ b/bay-services/gremlin.yaml
@@ -1,6 +1,6 @@
 services:
 - &gremlin_def
-  hash: d06d6db0f32e6dd2b4226c9672fb41a1261ae40e
+  hash: da4c10108f5741aab717bfcc0b70f298ffa3d49c 
   hash_length: 7
   name: gremlin-http
   environments:


### PR DESCRIPTION
It fixes the issue https://github.com/fabric8-analytics/f8a-server-backbone/issues/180 where gremlin http container is going OOM and killed.
PR - https://github.com/fabric8-analytics/gremlin-docker/pull/60
E2E Tests - https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/2200/console
