### PR TITLE
fix: update analytics repositories to point to the new s3 bucket

### DIFF
--- a/bay-services/f8a-hpf-insights.yaml
+++ b/bay-services/f8a-hpf-insights.yaml
@@ -1,6 +1,6 @@
 services:
 - &f8a-hpf-insights_def
-  hash: 70501a32913b3c20daa137d4d3b4916291561c35
+  hash: 7eaefef2da6ef36f688f9abded931dd05812efb6
   hash_length: 7
   name: f8a-hpf-insights-maven
   environments:

--- a/bay-services/f8a-pypi-insights.yaml
+++ b/bay-services/f8a-pypi-insights.yaml
@@ -1,6 +1,6 @@
 services:
 - &f8a-pypi-insights_def
-  hash: d9a56c92c031ee166c97ca8dc6734607e81d54e0
+  hash: 5ca9ec8c2d19a490041118f0c76181acf8145b01
   hash_length: 7
   name: f8a-pypi-insights
   environments:

--- a/bay-services/gemini.yaml
+++ b/bay-services/gemini.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 82d370d7fba4227bd6486efe6858c0ff9b91e26c
+- hash: a23d9784ffc9faf553cdf618aeeff351636c28dd
   hash_length: 7
   name: gemini
   environments:

--- a/bay-services/kronos.yaml
+++ b/bay-services/kronos.yaml
@@ -1,6 +1,6 @@
 services:
 - &kronos_def
-  hash: c9ce681201b6d869a9ddb7837c15a6165965e638
+  hash: 0c3c9b8bf940dd08672b52ef91340dbca4831c65
   hash_length: 7
   name: kronos-pypi
   environments:


### PR DESCRIPTION
The following repositories have been updated:

- https://github.com/fabric8-analytics/f8a-hpf-insights

- https://github.com/fabric8-analytics/f8a-pypi-insights
    PR: https://github.com/fabric8-analytics/f8a-pypi-insights/pull/61
    E2E: https://ci.centos.org/job/devtools-f8a-pypi-insights-f8a-build-master/42/console
- https://github.com/fabric8-analytics/fabric8-analytics-stack-analysis

- https://github.com/fabric8-analytics/fabric8-gemini-server
    PR: https://github.com/fabric8-analytics/fabric8-gemini-server/pull/202
    E2E: https://ci.centos.org/job/devtools-fabric8-gemini-server-f8a-build-master/165/console