### PR TITLE
Sentry Logs functionality added 

### DIFF
--- a/bay-services/metrics-accumulator.yaml
+++ b/bay-services/metrics-accumulator.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 45aea63380d9a587591ead63d34c68ba25bf1a0d
+- hash: 16a810dec483e4f8e49abf0ac77e4795cbf0e2b8
   hash_length: 7
   name: metrics-accumulator
   environments:


### PR DESCRIPTION
Before Merging we need to ensure SENTRY_DSN is set in Environment in `metrics-accumulator` service.

Merging should trigger restart accumulator service on Stage and Prod, hence metrics Counter should be reset 

PR: https://github.com/fabric8-analytics/metrics-accumulator/pull/10
E2E: https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/2260/
