### PR TITLE
guages reset flag added, Mapping data source variable changed.

### DIFF
--- a/bay-services/metrics-accumulator.yaml
+++ b/bay-services/metrics-accumulator.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 7c386318baaa4e1966d20fd174fc3e71f16f7208
+- hash: a2b5151b5886b3762bfd13ba720952466fa01e53
   hash_length: 7
   name: metrics-accumulator
   environments:

--- a/bay-services/metrics-accumulator.yaml
+++ b/bay-services/metrics-accumulator.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1279b7856313ef4f44431b12c5da91a41ed5b866
+- hash: 7c386318baaa4e1966d20fd174fc3e71f16f7208
   hash_length: 7
   name: metrics-accumulator
   environments:
@@ -8,10 +8,12 @@ services:
       FLASK_LOGGING_LEVEL: DEBUG
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-metrics-accumulator
+      RESET_COUNTER_ON_RESTART: 0
   - name: staging
     parameters:
       FLASK_LOGGING_LEVEL: DEBUG
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-metrics-accumulator
+      RESET_COUNTER_ON_RESTART: 0
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/metrics-accumulator/


### PR DESCRIPTION
Added Counter Reset Flag with valid values: 
0 -> OFF, 1->ON 
Flag will play its role when service got restarted.

Variable name for mapping data sources changed.
PR: Variable name changes https://github.com/fabric8-analytics/metrics-accumulator/pull/18
PR: Default Flag Turned Off https://github.com/fabric8-analytics/metrics-accumulator/pull/19 
E2E: https://ci.centos.org/job/devtools-metrics-accumulator-f8a-build-master/17/
