### PR TITLE
Overiding auto rate coversion of new  time series data 

### DIFF
--- a/bay-services/osd-monitor-poc.yaml
+++ b/bay-services/osd-monitor-poc.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1f5fe5487999ba8989f2fcb0acd28a7065f4a4f1
+- hash: bfd77cb3fcb986d6866bedf286d1bf215cf162a6
   name: osd-monitor-poc
   path: /bayesian-monitor.yml
   url: https://github.com/redhat-developer/osd-monitor-poc/


### PR DESCRIPTION
PCP Auto Rate Convert all incoming Data Series. To prevent this functionality we override newly introduced variables to output instantaneous values instead.

PR: https://github.com/redhat-developer/osd-monitor-poc/pull/55/
