### PR TITLE
Roll stack-report-ui upto 8809f75

### DIFF
--- a/bay-services/stack-report-ui.yaml
+++ b/bay-services/stack-report-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 4a48caf13332372f33f6ba27d39078b5048b19ae
+- hash: 8809f75de2e89f9bc3de515d9ef9eae8bbb0849a
   hash_length: 7
   name: stack-report-ui
   environments:


### PR DESCRIPTION
This PR rolls stack-report-ui to include the following PRs,

fabric8-analytics/fabric8-analytics-stack-report-ui#137
fabric8-analytics/fabric8-analytics-stack-report-ui#140

E2E test results: https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/2323/