### PR TITLE
Initiate celery-cleanup and weekly-retraining

### DIFF
--- a/bay-services/f8a-stacks-report.yaml
+++ b/bay-services/f8a-stacks-report.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 4b1d43f078768da05dc3c4ab536cfae6bf4749a4
+- hash: 789dc47252a10007e773fdacfe77d93c1b0e573f
   hash_length: 7
   name: f8a-stacks-report
   environments:


### PR DESCRIPTION
2 Main Changes:

Periodic cleanup of celery taskmeta tables:
PR: https://github.com/fabric8-analytics/f8a-stacks-report/pull/123
E2E: https://ci.centos.org/job/devtools-f8a-stacks-report-build-master/72/consoleFull

Weekly-retraining correction:
PR: https://github.com/fabric8-analytics/f8a-stacks-report/pull/122
E2E: https://ci.centos.org/job/devtools-f8a-stacks-report-build-master/71/consoleFull