### PR TITLE
trial to fix grafana data not showing up on app-sre-dashboard

### DIFF
--- a/bay-services/metrics-accumulator.yaml
+++ b/bay-services/metrics-accumulator.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: a2b5151b5886b3762bfd13ba720952466fa01e53
+- hash: d9448666683f6507e2277df17af76df63f3d78d9
   hash_length: 7
   name: metrics-accumulator
   environments:
@@ -10,6 +10,7 @@ services:
       CPU_LIMIT: 300m
       MEMORY_REQUEST: 128Mi
       MEMORY_LIMIT: 512Mi
+      METRICS_COLLECTOR_SERVICE_TIMEOUT: 120
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-metrics-accumulator
       RESET_COUNTER_ON_RESTART: 0

--- a/bay-services/osd-monitor-poc.yaml
+++ b/bay-services/osd-monitor-poc.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 0e7d7b0f2c0c368b1174e8b60e15f9a3a8b09348
+- hash: e2f855b6d2bc4d013e5343b33fa686162f6b6f95
   name: osd-monitor-poc
   path: /bayesian-monitor.yml
   url: https://github.com/redhat-developer/osd-monitor-poc/


### PR DESCRIPTION
### Issue
Grafana dashboard shows no data being populated. Checking the logs of pcp-prometheus-in shows that it is not able to ping metrics-accumulator service on port 5200. Trying to redeploy with some minor changes to see if it fixes the issue.

#### Metrics Accumulator
PR - https://github.com/fabric8-analytics/metrics-accumulator/pull/20
PR build - https://ci.centos.org/view/Devtools/job/devtools-metrics-accumulator-f8a-build-master/18/console
E2E Test - https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/2348/

#### Osd-Monitoring
PR - N/A
PR build - https://ci.centos.org/view/Devtools/job/devtools-osd-monitor-poc-build-master/207/
E2E Test - Not triggered