### PR TITLE
add timeout for pcp-prometheus-in

### DIFF
--- a/bay-services/osd-monitor-poc.yaml
+++ b/bay-services/osd-monitor-poc.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: e2f855b6d2bc4d013e5343b33fa686162f6b6f95
+- hash: 10c6b3081fbc49bcda1e5dff3ad70e707b47b08e
   name: osd-monitor-poc
   path: /bayesian-monitor.yml
   url: https://github.com/redhat-developer/osd-monitor-poc/


### PR DESCRIPTION
PR - https://github.com/redhat-developer/osd-monitor-poc/pull/57
E2E Tests - https://ci.centos.org/view/Devtools/job/devtools-osd-monitor-poc-build-master/211/console
### Issue with grafana dashboard
Currently grafana is not populating any metrics from osd-monitor.

#### RCA
`pcp-prometheus-in` is timing out requests to talk to metrics-accumulator service. 
Default `pmcd_timeout` is 2 seconds. It seems that [timeout value](https://github.com/redhat-developer/osd-monitor-poc/blob/master/pcp-prometheus-in/pmcd.sh#L40) is somewhere being overridden. 
With this [PR](https://github.com/redhat-developer/osd-monitor-poc/pull/57) I have tried to give explicit timeout of 20 seconds.
