### PR TITLE
introduce timeout as string value

### DIFF
--- a/bay-services/osd-monitor-poc.yaml
+++ b/bay-services/osd-monitor-poc.yaml
@@ -2,12 +2,5 @@ services:
 - hash: 4294a636d23f289937f2a0281e25cf539fe04d83
   hash_length: 7
   name: osd-monitor-poc
-  environments:
-  - name: production
-    parameters:
-      PMCD_TIMEOUT: "20"
-  - name: staging
-      parameters:
-      PMCD_TIMEOUT: "20"
   path: /bayesian-monitor.yml
   url: https://github.com/redhat-developer/osd-monitor-poc/

--- a/bay-services/osd-monitor-poc.yaml
+++ b/bay-services/osd-monitor-poc.yaml
@@ -1,6 +1,13 @@
 services:
-- hash: 10c6b3081fbc49bcda1e5dff3ad70e707b47b08e
+- hash: 4294a636d23f289937f2a0281e25cf539fe04d83
+  hash_length: 7
   name: osd-monitor-poc
+  environments:
+  - name: production
+    parameters:
+      PMCD_TIMEOUT: "20"
+  - name: staging
+      parameters:
+      PMCD_TIMEOUT: "20"
   path: /bayesian-monitor.yml
   url: https://github.com/redhat-developer/osd-monitor-poc/
-  hash_length: 7


### PR DESCRIPTION
Previous deployment failed with reason 
```
Error from server: cannot convert int64 to string
```

Introducing timeout param as string value
PR - https://github.com/redhat-developer/osd-monitor-poc/pull/58
E2E Tests - https://ci.centos.org/view/Devtools/job/devtools-osd-monitor-poc-build-master/213/console