### PR TITLE
revert the change for gaugify metrics

### DIFF
--- a/bay-services/metrics-accumulator.yaml
+++ b/bay-services/metrics-accumulator.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 079e3ee460f972cca01d12e113bdd4bfcbc7bad3
+- hash: 7d814cc5b3ffb2374592175852f5f6ad5abecb44
   hash_length: 7
   name: metrics-accumulator
   environments:


### PR DESCRIPTION
Converting rated metrics to instant values seems not to be working. This PR just reverts production metrics-accumulator to an older image. 
PR - N/A
E2E - N/A