### PR TITLE
fixes 202 status as error code

### DIFF
--- a/bay-services/api-backbone.yaml
+++ b/bay-services/api-backbone.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: c503fc78bcc3e976d445fc3cbc31f79036a22c5c
+- hash: 74e92711e9d9d491e4e5e3cac7a64fc8a8f555b8
   hash_length: 7
   name: api-backbone
   environments:

--- a/bay-services/api.yaml
+++ b/bay-services/api.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 24ab8a93b21143f5512fceed7b23b223dd15a00d
+- hash: a10bed5535b1f45325f5c4d421e7cd12e8a98086
   hash_length: 7
   name: api
   environments:


### PR DESCRIPTION
a) This patch removes 202 status code being tracked as an error in sentry. (API Server)
PR: https://github.com/fabric8-analytics/fabric8-analytics-server/pull/592
E2E: https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/2394/

b) Updating Utils and worker versions to remove `unknown package found errors`
PR: https://github.com/fabric8-analytics/f8a-server-backbone/pull/205
E2E: https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/2393/

c) Updating Secrets @miteshvp 
PR: https://github.com/fabric8-analytics/f8a-server-backbone/pull/206
E2E: https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/2393/

Jira: https://jira.coreos.com/browse/APPAI-1092