### PR TITLE
change aws secret naming conventions for offline flow

### DIFF
--- a/bay-services/f8a-emr-deployment.yaml
+++ b/bay-services/f8a-emr-deployment.yaml
@@ -1,6 +1,6 @@
 services:
 - &f8a-emr-deployment_def
-  hash: 1cf1f633e09fe1b9d926bb9bfb835b8a30669ca7
+  hash: 108065a86f01701023e9838eaec811d8f78b6596
   hash_length: 7
   name: f8a-emr-deployment
   environments:

--- a/bay-services/jobs.yaml
+++ b/bay-services/jobs.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 9279ad0fe183776e158b94e33f5162271754feac
+- hash: 4712e0538f41433f2893abe0fff7590c3be41010
   hash_length: 7
   name: jobs
   environments:

--- a/bay-services/release-monitor.yaml
+++ b/bay-services/release-monitor.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 43abf1711ed2c21d24edaf8f746e4f5ba20b7b10
+- hash: 54e5d9fede1059a9454a91718269cdb12dade9a9
   hash_length: 7
   name: fabric8-analytics-release-monitor
   environments:

--- a/bay-services/worker-scaler.yaml
+++ b/bay-services/worker-scaler.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 73c5c096ca5b6213f5c5587cfceb444873060105
+- hash: 9f157717af544da5835cd747125c6615746b4403
   hash_length: 7
   name: worker-scaler
   environments:

--- a/bay-services/worker.yaml
+++ b/bay-services/worker.yaml
@@ -1,7 +1,7 @@
 services:
 # INGESTION WORKERS
 - &worker_def
-  hash: d817aa6a3fdd059ab13efe512e34172cec704bc4
+  hash: 7a45c8a247135ad2c6ab88224939e60eb801979e
   hash_length: 7
   name: worker-ingestion
   environments:


### PR DESCRIPTION
1. Worker
PR - https://github.com/fabric8-analytics/fabric8-analytics-worker/pull/880
E2E - https://ci.centos.org/view/Devtools/job/devtools-fabric8-analytics-worker-f8a-build-master/463/ 
E2E retriggered - https://ci.centos.org/view/Devtools/job/devtools-fabric8-analytics-worker-f8a-build-master/464/ 


2. Scaler
PR - https://github.com/fabric8-analytics/fabric8-analytics-scaler/pull/70
E2E - https://ci.centos.org/view/Devtools/job/devtools-fabric8-analytics-scaler-f8a-build-master/64/ 
E2E retriggered - https://ci.centos.org/view/Devtools/job/devtools-fabric8-analytics-scaler-f8a-build-master/65/ 

3. Jobs
PR - https://github.com/fabric8-analytics/fabric8-analytics-jobs/pull/387
E2E - https://ci.centos.org/view/Devtools/job/devtools-fabric8-analytics-jobs-f8a-build-master/183/ 
E2E Retriggered - https://ci.centos.org/view/Devtools/job/devtools-fabric8-analytics-jobs-f8a-build-master/192/ 

4. EMR Deployment
PR - https://github.com/fabric8-analytics/f8a-emr-deployment/pull/51
E2E - https://ci.centos.org/job/devtools-f8a-emr-deployment-build-master/39/

5. Release Monitor
PR - https://github.com/fabric8-analytics/fabric8-analytics-release-monitor/pull/75
E2E - https://ci.centos.org/view/Devtools/job/devtools-fabric8-analytics-release-monitor-f8a-build-master/69/ 
