### PR TITLE
bump worker

### DIFF
--- a/bay-services/worker.yaml
+++ b/bay-services/worker.yaml
@@ -1,7 +1,7 @@
 services:
 # INGESTION WORKERS
 - &worker_def
-  hash: f77893e2c1d307f75f8d7c9b63b58169e76f56d5
+  hash: 54ef7bd8ecd388b78c06696b90729ed7837a48c9
   hash_length: 7
   name: worker-ingestion
   environments:


### PR DESCRIPTION
Worker API was not deployed properly. Dummy commit to promote to prod
Dummy Commit - https://github.com/fabric8-analytics/fabric8-analytics-worker/commit/54ef7bd8ecd388b78c06696b90729ed7837a48c9
E2E Test - https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/2420/