### PR TITLE
exclude golangCVEPredictionsFlow queue

### DIFF
--- a/bay-services/worker.yaml
+++ b/bay-services/worker.yaml
@@ -184,7 +184,7 @@ services:
   - name: production
     parameters:
       WORKER_ADMINISTRATION_REGION: api
-      WORKER_EXCLUDE_QUEUES: GraphImporterTask,bayesianAnalysisFlow,bayesianApiFlow,bayesianApiPackageFlow,bayesianFlow,bayesianPackageAnalysisFlow,bayesianPackageFlow,bayesianPackageTaggingFlow,bayesianPriorityFlow,bayesianPriorityPackageFlow
+      WORKER_EXCLUDE_QUEUES: GraphImporterTask,bayesianAnalysisFlow,bayesianApiFlow,bayesianApiPackageFlow,bayesianFlow,bayesianPackageAnalysisFlow,bayesianPackageFlow,bayesianPackageTaggingFlow,bayesianPriorityFlow,bayesianPriorityPackageFlow,golangCVEPredictionsFlow
       MEMORY_REQUEST: 256Mi
       MEMORY_LIMIT: 1536Mi
       CPU_REQUEST: 200m
@@ -195,7 +195,7 @@ services:
   - name: staging
     parameters:
       WORKER_ADMINISTRATION_REGION: api
-      WORKER_EXCLUDE_QUEUES: GraphImporterTask,bayesianAnalysisFlow,bayesianApiFlow,bayesianApiPackageFlow,bayesianFlow,bayesianPackageAnalysisFlow,bayesianPackageFlow,bayesianPackageTaggingFlow,bayesianPriorityFlow,bayesianPriorityPackageFlow
+      WORKER_EXCLUDE_QUEUES: GraphImporterTask,bayesianAnalysisFlow,bayesianApiFlow,bayesianApiPackageFlow,bayesianFlow,bayesianPackageAnalysisFlow,bayesianPackageFlow,bayesianPackageTaggingFlow,bayesianPriorityFlow,bayesianPriorityPackageFlow,golangCVEPredictionsFlow
       MEMORY_REQUEST: 256Mi
       MEMORY_LIMIT: 1024Mi
       CPU_REQUEST: 200m


### PR DESCRIPTION
Currently, bayesian-worker-api deployment in the production is failing with
```
INFO:__main__:Creating or requesting QueueURL for queue 'prod_api_golangCVEPredictionsFlow_v0'
Traceback (most recent call last):
  File "/usr/local/bin/queue_conf.py", line 87, in <module>
    set_queue_attributes(sys.argv[1].split(','))
  File "/usr/local/bin/queue_conf.py", line 38, in set_queue_attributes
    response = client.create_queue(QueueName=queue_name)
  File "/usr/local/lib/python3.6/site-packages/botocore/client.py", line 320, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/local/lib/python3.6/site-packages/botocore/client.py", line 623, in _make_api_call
    raise error_class(parsed_response, operation_name)
botocore.exceptions.ClientError: An error occurred (AccessDenied) when calling the CreateQueue operation: Access to the resource https://queue.amazonaws.com/ is denied.
```
This is happening because the said queue and flow are not persisted via app-sre-interface