### PR TITLE
handled 202 status code as error

### DIFF
--- a/bay-services/api.yaml
+++ b/bay-services/api.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 404c5a4261fade59880725e2189f835380ac13ea
+- hash: bc5601f0c0144946f7f413e0063bedb53537f93a
   hash_length: 7
   name: api
   environments:


### PR DESCRIPTION
Pushing 202 status code as error creates logs in sentry.  So, this PR removes 202 status code logged as Error in the component analysis. 

As frontend relies on key `error` in payload, so updating **message** key to **error** key to keep changes intact.

PR: https://github.com/fabric8-analytics/fabric8-analytics-server/pull/595
E2E: https://ci.centos.org/job/devtools-fabric8-analytics-server-f8a-build-master/335/
Jira: https://issues.redhat.com/browse/APPAI-1092
Frontend Issues: https://github.com/fabric8-analytics/fabric8-analytics-vscode-extension/issues/364