### PR TITLE
[gremlin-ingestion] Use legacy approach to limit jvm heap(using Xms, Xmx)

### DIFF
--- a/bay-services/gremlin.yaml
+++ b/bay-services/gremlin.yaml
@@ -46,7 +46,7 @@ services:
       MEMORY_LIMIT: 2688Mi
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
-      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1024m"
   - name: staging
     parameters:
       CHANNELIZER: http
@@ -59,6 +59,6 @@ services:
       MEMORY_LIMIT: 2688Mi
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
-      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1024m"
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/


### PR DESCRIPTION
I see that ingestion accuracy has been come down significantly due to long GC pauses from `gremlin-httpingestion` service. It was due to `-XX:+UseCGroupMemoryLimitForHeap`. As of now going back to legacy approach.

I'm evaluating to use [StandardOpProcessor](http://tinkerpop.apache.org/docs/current/reference/#_configuring_2) for gremlin which avoids having sessions and caches.