### PR TITLE
Disable gremlin/groovy script caching at Tinkerpop server

### DIFF
--- a/bay-services/data-importer.yaml
+++ b/bay-services/data-importer.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 446ee3838a04d72949574ed7e617c172d27ef2a7
+- hash: cbc91f5a389dc80c6c421807d79d8d5602874292
   hash_length: 7
   name: data-importer
   environments:


### PR DESCRIPTION
Queries generated from GraphPopulator are not [parameterized](https://github.com/fabric8-analytics/fabric8-analytics-data-model/blob/9e7e5dcc4433b93bea313c530d5bc795458ab236/src/graph_populator.py), but few other modules(like cve.py) does use script [parameterization](https://github.com/fabric8-analytics/fabric8-analytics-data-model/blob/9e7e5dcc4433b93bea313c530d5bc795458ab236/src/cve.py#L152).

Script parameterization [is recommended by Gremlin](http://tinkerpop.apache.org/docs/current/reference/#parameterized-scripts
) community. 

This is a workaround for https://issues.redhat.com/browse/APPAI-956. Proper solution would be to identifying all binding variables in the generated gremlin query and argument it.

PR: https://github.com/fabric8-analytics/fabric8-analytics-data-model/pull/328
Build status: https://ci.centos.org/job/devtools-fabric8-analytics-data-model-f8a-build-master/
e2e test result: https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/2423/