### PR TITLE
Revert "[gremlin-ingestion] Use legacy approach to limit jvm heap(using Xms, Xmx)"

### DIFF
--- a/bay-services/gremlin.yaml
+++ b/bay-services/gremlin.yaml
@@ -46,7 +46,7 @@ services:
       MEMORY_LIMIT: 2688Mi
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
-      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1024m"
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
   - name: staging
     parameters:
       CHANNELIZER: http
@@ -59,6 +59,6 @@ services:
       MEMORY_LIMIT: 2688Mi
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
-      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1024m"
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/


### PR DESCRIPTION
This reverts commit c24cf37a895b84e8b83cac19be0c2703515426cf.

Since #778 has disabled groovy/gremlin script caching at Tinkerpop sever, enabling cgroup based JVM heap settings should show some improvement now.