### PR TITLE
Revert "Revert "[gremlin-ingestion] Use legacy approach to limit jvm heap(using Xms, Xmx)""

### DIFF
--- a/bay-services/gremlin.yaml
+++ b/bay-services/gremlin.yaml
@@ -46,7 +46,7 @@ services:
       MEMORY_LIMIT: 2688Mi
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
-      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1024m"
   - name: staging
     parameters:
       CHANNELIZER: http
@@ -59,6 +59,6 @@ services:
       MEMORY_LIMIT: 2688Mi
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
-      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1024m"
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/


### PR DESCRIPTION
This reverts commit e0c438c2de55b034676f405b6b88bc6d42d716ee.

Still I see a rapid jvm heap growth regardless of fix https://github.com/fabric8-analytics/fabric8-analytics-data-model/pull/328. Currently working on to get jvm heap dump of gremlin http to see the top consumer instance type. 