### PR TITLE
Update default env var for sentry_report_helper in-order to migration to new-sentry

### DIFF
--- a/bay-services/f8a-stacks-report.yaml
+++ b/bay-services/f8a-stacks-report.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 2ed76a709fca4ee8e9bce55f4e0695859d643a48
+- hash: ad0d2b448d103cbd29c36aba5ac5e107a0b23a98
   hash_length: 7
   name: f8a-stacks-report
   environments:


### PR DESCRIPTION
PR : https://github.com/fabric8-analytics/f8a-stacks-report/pull/143

E2E : https://ci.centos.org/job/devtools-f8a-stacks-report-fabric8-analytics/289/console

Jira : https://issues.redhat.com/browse/APPAI-1159