### PR TITLE
Adding env variables to generate sentry report for staging

### DIFF
--- a/bay-services/f8a-stacks-report.yaml
+++ b/bay-services/f8a-stacks-report.yaml
@@ -19,5 +19,7 @@ services:
       CRON_SCHEDULE: "0 13 * * *"
       GITHUB_CVE_REPO: fabric8-analytics
       GENERATE_MANIFESTS: "True"
+      SENTRY_API_ISSUES: https://sentry.stage.devshift.net/api/0/projects/sentry/fabric8-analytics-stage/issues/
+      SENTRY_API_TAGS: https://sentry.stage.devshift.net/api/0/issues/
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/f8a-stacks-report


### PR DESCRIPTION
Adding env variables to generate sentry report for staging : https://sentry.stage.devshift.net/sentry/fabric8-analytics-stage/

- SENTRY_API_ISSUES: https://sentry.stage.devshift.net/api/0/projects/sentry/fabric8-analytics-stage/issues/

- SENTRY_API_TAGS: https://sentry.stage.devshift.net/api/0/issues/