### PR TITLE
New services related to osa api server

### DIFF
--- a/bay-services/osa-api.yaml
+++ b/bay-services/osa-api.yaml
@@ -1,0 +1,18 @@
+services:
+- hash: none
+  hash_length: 7
+  name: api
+  environments:
+  - name: staging
+    parameters:
+      REPLICAS: 1
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/osa-api-server
+  - name: production
+    parameters:
+      REPLICAS: 1
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/osa-api-server
+      API_SERVER_HOSTNAME:
+  path: /openshift/template.yaml
+  url: https://github.com/kubesecurity/osa-api-server/

--- a/bay-services/osa-gremlin.yaml
+++ b/bay-services/osa-gremlin.yaml
@@ -1,0 +1,33 @@
+services:
+- hash: None
+  hash_length: 7
+  name: osa-gremlin-http
+  environments:
+  - name: production
+    parameters:
+      CHANNELIZER: http
+      REST_VALUE: 1
+      REPLICAS: 1
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
+      CPU_REQUEST: 100m
+      CPU_LIMIT: 300m
+      MEMORY_REQUEST: 640Mi
+      MEMORY_LIMIT: 2688Mi
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      DYNAMODB_INSTANCE_PREFIX: "osa"
+  - name: staging
+    parameters:
+      CHANNELIZER: http
+      REST_VALUE: 1
+      REPLICAS: 1
+      CPU_REQUEST: 100m
+      CPU_LIMIT: 300m
+      MEMORY_REQUEST: 640Mi
+      MEMORY_LIMIT: 2688Mi
+      DOCKER_REGISTRY: quay.io
+      DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      DYNAMODB_INSTANCE_PREFIX: "osa"
+  path: /openshift/template.yaml
+  url: https://github.com/fabric8-analytics/gremlin-docker/


### PR DESCRIPTION
Added two service file which helps to deploy OSA Api Server. 

- One service for deploying gremlin which will used by osa-api-server (osa-gremlin.yaml)
- One service for deploying osa-api-server (osa-api.yaml)