### PR TITLE
OSA Gremlin - Updated hash and java options

### DIFF
--- a/bay-services/osa-gremlin.yaml
+++ b/bay-services/osa-gremlin.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: None
+- hash: 808d4708395b1e36dd2c56baeaedecb604f12c34
   hash_length: 7
   name: osa-gremlin-http
   environments:
@@ -14,7 +14,7 @@ services:
       CPU_LIMIT: 300m
       MEMORY_REQUEST: 640Mi
       MEMORY_LIMIT: 2688Mi
-      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1400m"
       DYNAMODB_INSTANCE_PREFIX: "osa"
   - name: staging
     parameters:
@@ -27,7 +27,7 @@ services:
       MEMORY_LIMIT: 2688Mi
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
-      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -XX:+UnlockExperimentalVMOptions -XX:+UseCGroupMemoryLimitForHeap"
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1400m"
       DYNAMODB_INSTANCE_PREFIX: "osa"
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/


### PR DESCRIPTION
* Updated hash so that we can deploy gremlin service with 'osa' as dynamodb table prefix
* Made java option same as dependancy analytics.