### PR TITLE
OSA : Reading dynamodb secret name from parameter

### DIFF
--- a/bay-services/osa-gremlin.yaml
+++ b/bay-services/osa-gremlin.yaml
@@ -16,6 +16,7 @@ services:
       MEMORY_LIMIT: 2688Mi
       JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1400m"
       DYNAMODB_INSTANCE_PREFIX: "osa"
+      DYNAMODB_SECRET_NAME: "aws-dynamodb-osa"
   - name: staging
     parameters:
       CHANNELIZER: http
@@ -29,5 +30,6 @@ services:
       DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
       JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1400m"
       DYNAMODB_INSTANCE_PREFIX: "osa"
+      DYNAMODB_SECRET_NAME: "aws-dynamodb-osa"
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/

--- a/bay-services/osa-gremlin.yaml
+++ b/bay-services/osa-gremlin.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 808d4708395b1e36dd2c56baeaedecb604f12c34
+- hash: 004c6fc529666b6354c5fb714924ba5b1e9cc734
   hash_length: 7
   name: osa-gremlin-http
   environments:


### PR DESCRIPTION
For osa gremlin service, we require to use different secret name "aws-dynamodb-osa", so reading it from parameter.

Ref PR : https://github.com/fabric8-analytics/gremlin-docker/pull/77
Commit : https://github.com/fabric8-analytics/gremlin-docker/commit/004c6fc529666b6354c5fb714924ba5b1e9cc734