### PR TITLE
OSA Gremlin: Added new param to STAGE environment

### DIFF
--- a/bay-services/osa-gremlin.yaml
+++ b/bay-services/osa-gremlin.yaml
@@ -31,5 +31,6 @@ services:
       JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1400m"
       DYNAMODB_INSTANCE_PREFIX: "osa"
       DYNAMODB_SECRET_NAME: "aws-dynamodb-osa"
+      DYNAMODB_PREFIX_KEY: "osa-dynamodb-prefix"
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/


### PR DESCRIPTION
For osa gremlin service, we require to use different DYNAMODB_PREFIX_KEY as "osa-dynamodb-prefix", so reading it from parameter. Adding changes to only STGAGE so can verify there after PR merge. 

Ref PR : https://github.com/fabric8-analytics/gremlin-docker/pull/81