### PR TITLE
OSA Gremlin: Added  dynamodb prefix param for PROD

### DIFF
--- a/bay-services/osa-gremlin.yaml
+++ b/bay-services/osa-gremlin.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 004c6fc529666b6354c5fb714924ba5b1e9cc734
+- hash: b15ded9ce32642e971eb4d85a2174c7645eb2226
   hash_length: 7
   name: osa-gremlin-http
   environments:
@@ -17,6 +17,7 @@ services:
       JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1400m"
       DYNAMODB_INSTANCE_PREFIX: "osa"
       DYNAMODB_SECRET_NAME: "aws-dynamodb-osa"
+      DYNAMODB_PREFIX_KEY: "osa-dynamodb-prefix"
   - name: staging
     parameters:
       CHANNELIZER: http


### PR DESCRIPTION
For osa gremlin service, we require to use different DYNAMODB_PREFIX_KEY as "osa-dynamodb-prefix", so reading it from parameter. Working fine in STAGE so updated for PROD as well. 


Ref PR : https://github.com/fabric8-analytics/gremlin-docker/pull/81
Commit : https://github.com/fabric8-analytics/gremlin-docker/commit/b15ded9ce32642e971eb4d85a2174c7645eb2226