### PR TITLE
OSA : Updated Hash and Replica for api server

### DIFF
--- a/bay-services/osa-api.yaml
+++ b/bay-services/osa-api.yaml
@@ -1,18 +1,17 @@
 services:
-- hash: none
+- hash: e612035a5e0b3551d5db745365e728d05518e3cb
   hash_length: 7
   name: osa-api-server
   environments:
   - name: staging
     parameters:
-      REPLICAS: 1
+      REPLICAS: 3
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/osa-api-server
   - name: production
     parameters:
-      REPLICAS: 1
+      REPLICAS: 3
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/osa-api-server
-      API_SERVER_HOSTNAME:
   path: /openshift/template.yaml
   url: https://github.com/kubesecurity/osa-api-server/


### PR DESCRIPTION
Updated hash so we can deploy osa api to prod environment. 

Ref PR : https://github.com/kubesecurity/osa-api-server/pull/12
Commit : https://github.com/kubesecurity/osa-api-server/commit/e612035a5e0b3551d5db745365e728d05518e3cb