### PR TITLE
Update parameters for env-var 'SENTRY_API_ISSUES' and 'SENTRY_API_TAGS'

### DIFF
--- a/bay-services/f8a-stacks-report.yaml
+++ b/bay-services/f8a-stacks-report.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: ad0d2b448d103cbd29c36aba5ac5e107a0b23a98
+- hash: 1decabb2440cedd3e4b6b830192267e1e906927a
   hash_length: 7
   name: f8a-stacks-report
   environments:
@@ -10,6 +10,8 @@ services:
       CRON_SCHEDULE: "0 4 * * *"
       GITHUB_CVE_REPO: fabric8-analytics
       GENERATE_MANIFESTS: "False"
+      SENTRY_API_ISSUES: "/api/0/projects/sentry/fabric8-analytics-production/issues/"
+      SENTRY_API_TAGS: "/api/0/issues/"
   - name: staging
     parameters:
       MEMORY_REQUEST: "2048Mi"
@@ -19,7 +21,7 @@ services:
       CRON_SCHEDULE: "0 13 * * *"
       GITHUB_CVE_REPO: fabric8-analytics
       GENERATE_MANIFESTS: "True"
-      SENTRY_API_ISSUES: https://sentry.stage.devshift.net/api/0/projects/sentry/fabric8-analytics-stage/issues/
-      SENTRY_API_TAGS: https://sentry.stage.devshift.net/api/0/issues/
+      SENTRY_API_ISSUES: "/api/0/projects/sentry/fabric8-analytics-stage/issues/"
+      SENTRY_API_TAGS: "/api/0/issues/"
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/f8a-stacks-report


### PR DESCRIPTION
**Update parameters for env-var 'SENTRY_API_ISSUES' and 'SENTRY_API_TAGS'** : 
Using 'sentry-url' from vault secret with respect to production or staging Sentry URL to generate the 'sentry-api-issues' and 'sentry-api-tags' URLs.

PR : https://github.com/fabric8-analytics/f8a-stacks-report/pull/149 

E2E : https://ci.centos.org/job/devtools-f8a-stacks-report-fabric8-analytics/313/console 