### PR TITLE
Update github-refresh-cronjob.yaml

### DIFF
--- a/bay-services/github-refresh-cronjob.yaml
+++ b/bay-services/github-refresh-cronjob.yaml
@@ -7,7 +7,7 @@ services:
     parameters:
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-github-refresh-cronjob
-      DRY_RUN: 0
+      DRY_RUN: 1
       CRON_SCHEDULE: "0 7 * * *"
   - name: staging
     parameters:


### PR DESCRIPTION
stopping gh refresh job for a week to reduce load on the queue