### PR TITLE
OSA: Updated osa api hash, assigned replica to 3

### DIFF
--- a/bay-services/osa-api.yaml
+++ b/bay-services/osa-api.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: e612035a5e0b3551d5db745365e728d05518e3cb
+- hash: 26a1373228941d2597fca9a2fcd6ce76efb96759
   hash_length: 7
   name: osa-api-server
   environments:

--- a/bay-services/osa-gremlin.yaml
+++ b/bay-services/osa-gremlin.yaml
@@ -7,7 +7,7 @@ services:
     parameters:
       CHANNELIZER: http
       REST_VALUE: 1
-      REPLICAS: 1
+      REPLICAS: 3
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
       CPU_REQUEST: 100m
@@ -22,7 +22,7 @@ services:
     parameters:
       CHANNELIZER: http
       REST_VALUE: 1
-      REPLICAS: 1
+      REPLICAS: 3
       CPU_REQUEST: 100m
       CPU_LIMIT: 300m
       MEMORY_REQUEST: 640Mi


### PR DESCRIPTION
Updated hash so we can deploy latest code of osa api to prod environment. Also set replicas to 3 from 1. 

Ref PR : https://github.com/kubesecurity/osa-api-server/pull/13
Commit : https://github.com/kubesecurity/osa-api-server/commit/26a1373228941d2597fca9a2fcd6ce76efb96759