### PR TITLE
Bumping replica count for snyk ingestion load handling

### DIFF
--- a/bay-services/data-importer.yaml
+++ b/bay-services/data-importer.yaml
@@ -5,7 +5,7 @@ services:
   environments:
   - name: production
     parameters:
-      REPLICAS: 10
+      REPLICAS: 13
       CPU_REQUEST: 100m
       CPU_LIMIT: 300m
       MEMORY_REQUEST: 500Mi
@@ -14,7 +14,7 @@ services:
       DOCKER_IMAGE: openshiftio/rhel-bayesian-data-model-importer
   - name: staging
     parameters:
-      REPLICAS: 1
+      REPLICAS: 3
       CPU_REQUEST: 100m
       CPU_LIMIT: 200m
       MEMORY_REQUEST: 500Mi

--- a/bay-services/gremlin.yaml
+++ b/bay-services/gremlin.yaml
@@ -8,7 +8,7 @@ services:
     parameters:
       CHANNELIZER: http
       REST_VALUE: 1
-      REPLICAS: 6
+      REPLICAS: 9
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
       CPU_REQUEST: 100m
@@ -20,7 +20,7 @@ services:
     parameters:
       CHANNELIZER: http
       REST_VALUE: 1
-      REPLICAS: 1
+      REPLICAS: 3
       CPU_REQUEST: 100m
       CPU_LIMIT: 300m
       MEMORY_REQUEST: 1024Mi
@@ -39,7 +39,7 @@ services:
       CHANNELIZER: http
       QUERY_ADMINISTRATION_REGION: ingestion
       REST_VALUE: 1
-      REPLICAS: 10
+      REPLICAS: 12
       CPU_REQUEST: 100m
       CPU_LIMIT: 300m
       MEMORY_REQUEST: 640Mi
@@ -52,7 +52,7 @@ services:
       CHANNELIZER: http
       QUERY_ADMINISTRATION_REGION: ingestion
       REST_VALUE: 1
-      REPLICAS: 1
+      REPLICAS: 3
       CPU_REQUEST: 100m
       CPU_LIMIT: 300m
       MEMORY_REQUEST: 640Mi


### PR DESCRIPTION
This is needed as the input data is high and ingestion on the stage server would cause problems with only 1 replica running.