### PR TITLE
Disabling snyk sync operation on staging

### DIFF
--- a/bay-services/graph-cve-sync.yaml
+++ b/bay-services/graph-cve-sync.yaml
@@ -15,5 +15,8 @@ services:
       DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-graph-cve-sync
       SYNC_MODE: diff #diff for differential sync and full for whole sync
       #CRON_SCHEDULE: "0 */1 * * *"
+      SNYK_DRY_RUN: false
+      SNYK_DELTA_FEED_MODE: false
+      DISABLE_SNYK_SYNC_OPERATION: true
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/graph-cve-sync


### PR DESCRIPTION
This is to disable the snyk sync operation from running as the snyk data is already ingested in the staging cluster. We need not run in again, till the delta feed logic is added