### PR TITLE
updating venus report query

### DIFF
--- a/bay-services/f8a-stacks-report.yaml
+++ b/bay-services/f8a-stacks-report.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1decabb2440cedd3e4b6b830192267e1e906927a
+- hash: a9eeb971049c99d1a6dee5016b9782c56318cb97
   hash_length: 7
   name: f8a-stacks-report
   environments:

--- a/bay-services/f8a-stacks-report.yaml
+++ b/bay-services/f8a-stacks-report.yaml
@@ -9,7 +9,7 @@ services:
       DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-stacks-report
       CRON_SCHEDULE: "0 4 * * *"
       GITHUB_CVE_REPO: fabric8-analytics
-      GENERATE_MANIFESTS: "False"
+      GENERATE_MANIFESTS: "false"
       SENTRY_API_ISSUES: "/api/0/projects/sentry/fabric8-analytics-production/issues/"
       SENTRY_API_TAGS: "/api/0/issues/"
   - name: staging
@@ -20,7 +20,7 @@ services:
       DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-stacks-report
       CRON_SCHEDULE: "0 13 * * *"
       GITHUB_CVE_REPO: fabric8-analytics
-      GENERATE_MANIFESTS: "True"
+      GENERATE_MANIFESTS: "false"
       SENTRY_API_ISSUES: "/api/0/projects/sentry/fabric8-analytics-stage/issues/"
       SENTRY_API_TAGS: "/api/0/issues/"
   path: /openshift/template.yaml


### PR DESCRIPTION
This PR will update Venus Report RDS query which to fetch v1 only Stack Analyses Data.

PR: https://github.com/fabric8-analytics/f8a-stacks-report/pull/153
Jira: https://issues.redhat.com/browse/APPAI-1257
E2E: https://ci.centos.org/job/devtools-f8a-stacks-report-build-master/98/
 
Signed-off-by: Deepak Sharma <deepshar@redhat.com>