### PR TITLE
Update graph-cve-sync.yaml

### DIFF
--- a/bay-services/graph-cve-sync.yaml
+++ b/bay-services/graph-cve-sync.yaml
@@ -16,7 +16,7 @@ services:
       SYNC_MODE: diff #diff for differential sync and full for whole sync
       #CRON_SCHEDULE: "0 */1 * * *"
       SNYK_DRY_RUN: false
-      SNYK_DELTA_FEED_MODE: false
-      DISABLE_SNYK_SYNC_OPERATION: true
+      SNYK_DELTA_FEED_MODE: true
+      DISABLE_SNYK_SYNC_OPERATION: false
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/graph-cve-sync


### PR DESCRIPTION
Changes to enable delta feed mode on the staging cluster. Its not yet promoted to prod and hence no changes are added for the production envs, nor is the commit hash being changed. It will be updated once the team completes its round of testing the changes for snyk
Details:
Jira: https://issues.redhat.com/browse/APPAI-1245
PR: https://github.com/fabric8-analytics/graph-cve-sync/pull/27