### PR TITLE
[osa] Remove cron sched value for now

### DIFF
--- a/bay-services/openshift-probable-vulnerabilities.yaml
+++ b/bay-services/openshift-probable-vulnerabilities.yaml
@@ -6,10 +6,8 @@ services:
   - name: staging
     parameters:
       REPLICAS: 1
-      CRON_SCHEDULE: "0 1 * * MON"
   - name: production
     parameters:
       REPLICAS: 1
-      CRON_SCHEDULE: "0 1 * * MON"
   path: /deployment/template-cronjob.yaml
   url: https://github.com/kubesecurity/openshift-probable-vulnerabilities/


### PR DESCRIPTION
This is for debugging purpose, the default value is already present in https://github.com/kubesecurity/openshift-probable-vulnerabilities/blob/master/deployment/template-cronjob.yaml#L143