### PR TITLE
Reverting the PR due to errors showing in Production

### DIFF
--- a/bay-services/worker.yaml
+++ b/bay-services/worker.yaml
@@ -1,7 +1,7 @@
 services:
 # INGESTION WORKERS
 - &worker_def
-  hash: fb0cf1a149f096db86bb3779e7bb4cf076d7fb08
+  hash: 5f80568f3e922f20556139e78690b3e7008cb5b3
   hash_length: 7
   name: worker-ingestion
   environments:


### PR DESCRIPTION
Reverting the PR, because it is showing error for some packages in production logs