### PR TITLE
[backbone] Increase staging replica to 3

### DIFF
--- a/bay-services/api-backbone.yaml
+++ b/bay-services/api-backbone.yaml
@@ -19,7 +19,7 @@ services:
       CPU_LIMIT: 1
       MEMORY_REQUEST: 500Mi
       MEMORY_LIMIT: 512Mi
-      REPLICAS: 2
+      REPLICAS: 3
       FLASK_LOGGING_LEVEL: DEBUG
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-server-backbone


### PR DESCRIPTION
API server invokes 2 services every on backbone for each request. The load won't be distributed evenly with the existing 2 replicas. Increasing it to odd number would help to distribute the load properly.