### PR TITLE
fix: Remove unused service config files

### DIFF
--- a/bay-services/api-gateway.yaml
+++ b/bay-services/api-gateway.yaml
@@ -1,9 +1,0 @@
-services:
-- hash: 
-  hash_length: 7
-  name: api-gateway
-  environments:
-  - name: production
-  - name: staging
-  path: /openshift/template.yaml
-  url: https://github.com/fabric8-analytics/fabric8-analytics-api-gateway/

--- a/bay-services/api-machine-stacks.yaml
+++ b/bay-services/api-machine-stacks.yaml
@@ -1,6 +1,0 @@
-services:
-- hash: none
-  hash_length: 7
-  name: api-machine-stacks
-  path: /openshift/template.yaml
-  url: https://github.com/fabric8-analytics/api-machine-stacks/


### PR DESCRIPTION
These services are not in production and not used anywhere in staging too. Removing these to keep staging cluster clutter free.