### PR TITLE
Fix: Use custom selinon with patch to drain message if it is old

### DIFF
--- a/bay-services/worker.yaml
+++ b/bay-services/worker.yaml
@@ -1,7 +1,7 @@
 services:
 # INGESTION WORKERS
 - &worker_def
-  hash: 6b12a855288dd624a0d715edd2ee6a91c62d25a5
+  hash: 248d4a827603decd4946f4349eaa0c7aad5cf53d
   hash_length: 7
   name: worker-ingestion
   environments:


### PR DESCRIPTION
# Description

Used a custom selinon package to handle the long pending messages in dispatcher.

## Git PR
https://github.com/fabric8-analytics/fabric8-analytics-worker/pull/903

## centOS Build
https://ci.centos.org/job/devtools-fabric8-analytics-worker-f8a-build-master/494/

## Jira Ticket
https://issues.redhat.com/browse/APPAI-1359
