### PR TITLE
Removal of source_licenses and libraries_io tasks from the ingestion flow

### DIFF
--- a/bay-services/worker.yaml
+++ b/bay-services/worker.yaml
@@ -1,7 +1,7 @@
 services:
 # INGESTION WORKERS
 - &worker_def
-  hash: 248d4a827603decd4946f4349eaa0c7aad5cf53d
+  hash: fdc0435f78787faace36f02c1228dbf57e5ed938
   hash_length: 7
   name: worker-ingestion
   environments:


### PR DESCRIPTION
# Description
Removed source_licenses and libraries_io tasks from the ingestion flow as it is not useful anymore.

## Jira Ticket
https://issues.redhat.com/browse/APPAI-1370

## Git PR
https://github.com/fabric8-analytics/fabric8-analytics-worker/pull/904

## CentOS Build
https://ci.centos.org/job/devtools-fabric8-analytics-worker-f8a-build-master/495/
