### PR TITLE
[hpf-insights] Remove unused param USE_FEEDBACK

### DIFF
--- a/bay-services/f8a-hpf-insights.yaml
+++ b/bay-services/f8a-hpf-insights.yaml
@@ -25,7 +25,6 @@ services:
       REPLICAS: 1
       DOCKER_REGISTRY: quay.io
       RESTART_POLICY: Always
-      USE_FEEDBACK: true
       MODEL_VERSION: "2019-01-03"
   path: /openshift/template-prod.yaml
   url: https://github.com/fabric8-analytics/f8a-hpf-insights/


### PR DESCRIPTION
Usage of USE_FEEDBACK has been removed by https://github.com/fabric8-analytics/f8a-hpf-insights/pull/80. Also the value of USE_FEEDBACK is set as `true` from saas-analytics which is causing the following error in the staging CD job,

```
Error from server: unrecognized type: string
```
Refer: https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/2484/console