### PR TITLE
[stack-report ui] Promote v2 UI changes to production

### DIFF
--- a/bay-services/stack-report-ui.yaml
+++ b/bay-services/stack-report-ui.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 8809f75de2e89f9bc3de515d9ef9eae8bbb0849a
+- hash: f5503b2cbe0f2416e3dae6a3f05b29b9496f9690
   hash_length: 7
   name: stack-report-ui
   environments:


### PR DESCRIPTION
New Stack Report UI upto [f5503b2cbe0f2416e3dae6a3f05b29b9496f9690 ](https://github.com/fabric8-analytics/fabric8-analytics-stack-report-ui/commits/master) for 0.1.0 release.