### PR TITLE
Updating worker version same as API server and backbone.

### DIFF
--- a/bay-services/github-refresh-cronjob.yaml
+++ b/bay-services/github-refresh-cronjob.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 269f9ca3ffa1cdeb29d7adb97ab271d1a2247b5f
+- hash: da60851bac8ddfba9eacc6dddc66b7d9c11137c6
   hash_length: 7
   name: fabric8-analytics-github-refresh-cronjob
   environments:
@@ -7,7 +7,7 @@ services:
     parameters:
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-github-refresh-cronjob
-      DRY_RUN: 1
+      DRY_RUN: 0
       CRON_SCHEDULE: "0 7 * * *"
   - name: staging
     parameters:


### PR DESCRIPTION
# Description
Updating refresh worker dependency version similar as API server and backbone.
With old version facing some issue in GitDB library as its been upgraded.
Also updated DRY_RUN to 0 for Production

## Jira Ticket
https://issues.redhat.com/browse/APPAI-1412

## CentOS Build
https://ci.centos.org/job/devtools-fabric8-analytics-github-refresh-cronjob-build-master-v4/2/

## Git PR
https://github.com/fabric8-analytics/fabric8-analytics-github-refresh-cronjob/pull/48