### PR TITLE
Update f8a-stacks-report.yaml

### DIFF
--- a/bay-services/f8a-stacks-report.yaml
+++ b/bay-services/f8a-stacks-report.yaml
@@ -7,7 +7,7 @@ services:
     parameters:
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-f8a-stacks-report
-      CRON_SCHEDULE: "0 4 * * *"
+      CRON_SCHEDULE: "15 0 * * *"
       GITHUB_CVE_REPO: fabric8-analytics
       GENERATE_MANIFESTS: "false"
       SENTRY_API_ISSUES: "/api/0/projects/sentry/fabric8-analytics-production/issues/"


### PR DESCRIPTION
Had changed the schedule to 4 am as there was a backlog of msgs and we were trying to give it more time to ingest and then generate the report. Now that we have got rid of the backlog, its better to generate the report at the desired time.