### PR TITLE
Update github-refresh-cronjob.yaml

### DIFF
--- a/bay-services/github-refresh-cronjob.yaml
+++ b/bay-services/github-refresh-cronjob.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: da60851bac8ddfba9eacc6dddc66b7d9c11137c6
+- hash: bbe59fe70a29fd9bd4e720fce6be88e9928ad81b
   hash_length: 7
   name: fabric8-analytics-github-refresh-cronjob
   environments:
@@ -8,7 +8,7 @@ services:
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-github-refresh-cronjob
       DRY_RUN: 0
-      CRON_SCHEDULE: "0 7 * * *"
+      CRON_SCHEDULE: "0 3 * * *"
   - name: staging
     parameters:
       DOCKER_REGISTRY: quay.io


### PR DESCRIPTION
E2E: https://ci.centos.org/job/devtools-fabric8-analytics-github-refresh-cronjob-build-master-v4/3/console
PR: https://github.com/fabric8-analytics/fabric8-analytics-github-refresh-cronjob/pull/49
Jira: https://issues.redhat.com/browse/APPAI-1402