### PR TITLE
Update graph-cve-sync.yaml

### DIFF
--- a/bay-services/graph-cve-sync.yaml
+++ b/bay-services/graph-cve-sync.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1f078222e3000edcdba0a37dab4b86892a64ec67
+- hash: d7d2b7a2844ac4517c5b8607fe6618b6f04c7b52
   hash_length: 7
   name: graph-cve-sync
   environments:
@@ -9,7 +9,8 @@ services:
       DOCKER_IMAGE: openshiftio/rhel-fabric8-analytics-graph-cve-sync
       SYNC_MODE: diff #diff for differential sync and full for whole sync
       CRON_SCHEDULE: "0 */6 * * *"
-      SNYK_DELTA_FEED_MODE: true
+      SNYK_DELTA_FEED_MODE: false
+      SNYK_INGESTION_FORCE_RUN: true
   - name: staging
     parameters:
       DOCKER_REGISTRY: quay.io


### PR DESCRIPTION
Turning on force run, just for a day to run the entire python feed to rectify the problem with pkg names with caps. After the feed is completed successfully, the flags 
SNYK_DELTA_FEED_MODE: false
      SNYK_INGESTION_FORCE_RUN: true
will be switched back

E2E: https://ci.centos.org/job/devtools-graph-cve-sync-build-master-v4/2/consoleFull
PR: https://github.com/fabric8-analytics/graph-cve-sync/pull/35
Jira: https://issues.redhat.com/browse/APPAI-1425