### PR TITLE
OSA: Updated inference job hash

### DIFF
--- a/bay-services/openshift-probable-vulnerabilities.yaml
+++ b/bay-services/openshift-probable-vulnerabilities.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 4727cd623155c4d9e5ca01e089b859245ab7a9aa
+- hash: 58fda84141f1175eb79143eb362e230c99e25a2a
   hash_length: 7
   name: openshift-probable-vulnerabilities
   environments:


### PR DESCRIPTION
Updated hash for the inference job so we can deploy latest code of inference to prod environment.

Ref PRs : https://github.com/kubesecurity/openshift-probable-vulnerabilities/pull/40
Commit : https://github.com/kubesecurity/openshift-probable-vulnerabilities/commit/58fda84141f1175eb79143eb362e230c99e25a2a