### PR TITLE
Update graph-cve-sync.yaml

### DIFF
--- a/bay-services/graph-cve-sync.yaml
+++ b/bay-services/graph-cve-sync.yaml
@@ -11,6 +11,7 @@ services:
       CRON_SCHEDULE: "0 */6 * * *"
       SNYK_DELTA_FEED_MODE: true
       SNYK_INGESTION_FORCE_RUN: false
+      SNYK_INGESTION_RUN_TIME: "12"
   - name: staging
     parameters:
       DOCKER_REGISTRY: quay.io


### PR DESCRIPTION
updating it to run 6 hrs earlier today. Will set it to run at 00 hrs from now on so that we can get to see the results the first thing in the morning.