### PR TITLE
Update graph-cve-sync.yaml

### DIFF
--- a/bay-services/graph-cve-sync.yaml
+++ b/bay-services/graph-cve-sync.yaml
@@ -11,7 +11,7 @@ services:
       CRON_SCHEDULE: "0 */6 * * *"
       SNYK_DELTA_FEED_MODE: true
       SNYK_INGESTION_FORCE_RUN: false
-      SNYK_DELTA_FEED_OFFSET: "24"
+      SNYK_DELTA_FEED_OFFSET: "27"
   - name: staging
     parameters:
       DOCKER_REGISTRY: quay.io

--- a/bay-services/graph-cve-sync.yaml
+++ b/bay-services/graph-cve-sync.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 64806e1b805a040634aa62ef136152d2eb61898b
+- hash: 2a86089a40db728765537a6ad60a11c65df6d047
   hash_length: 7
   name: graph-cve-sync
   environments:

--- a/bay-services/graph-cve-sync.yaml
+++ b/bay-services/graph-cve-sync.yaml
@@ -11,7 +11,6 @@ services:
       CRON_SCHEDULE: "0 */6 * * *"
       SNYK_DELTA_FEED_MODE: true
       SNYK_INGESTION_FORCE_RUN: false
-      SNYK_INGESTION_RUN_TIME: "00"
       SNYK_DELTA_FEED_OFFSET: "24"
   - name: staging
     parameters:


### PR DESCRIPTION
Additional logs for the clarity of env variable values etc. Today we just print that "snyk feed wont run at this time". With this change, we will get to know the values of the env variables etc so that dev can get more clarity from logs.
https://github.com/fabric8-analytics/graph-cve-sync/pull/40