### PR TITLE
Fix: Github statistics/Enhancement: Selinon to drain out problematic messages

### DIFF
--- a/bay-services/worker.yaml
+++ b/bay-services/worker.yaml
@@ -1,7 +1,7 @@
 services:
 # INGESTION WORKERS
 - &worker_def
-  hash: fdc0435f78787faace36f02c1228dbf57e5ed938
+  hash: bc0a3b65d1b06c72a6c0593e4fd9f465cff2baa8
   hash_length: 7
   name: worker-ingestion
   environments:


### PR DESCRIPTION
# Fix
## Description
Introduced pagination in Git hub contributor count URL, as it was not going beyond 30.   

### Jira Ticket
https://issues.redhat.com/browse/APPAI-1359

### Git PR
https://github.com/fabric8-analytics/fabric8-analytics-worker/pull/915

### CentOS Build
https://ci.centos.org/job/devtools-fabric8-analytics-worker-f8a-build-master/497/ (Pulled changes, but failed)
https://ci.centos.org/job/devtools-fabric8-analytics-worker-f8a-build-master/498/ (Dummy build)


# Enhancement

## Description
Used monkey patching to ingest the logic in Selinon to drain out messages which are stuck in queue for more than configured time. Also removed binary file used previously to handle this issue and used PyPi registry.

### Jira Ticket
https://issues.redhat.com/browse/APPAI-1432

### Git PR
https://github.com/fabric8-analytics/fabric8-analytics-worker/pull/911

### CentOS Build
https://ci.centos.org/job/devtools-fabric8-analytics-worker-f8a-build-master/499/ (Pulled changes, but failed)
https://ci.centos.org/job/devtools-fabric8-analytics-worker-f8a-build-master/501/ (Dummy build)