### PR TITLE
OSA: Updated hash for inference job

### DIFF
--- a/bay-services/openshift-probable-vulnerabilities.yaml
+++ b/bay-services/openshift-probable-vulnerabilities.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 58fda84141f1175eb79143eb362e230c99e25a2a
+- hash: e245131c7e720b39f1af498740d10d5470228df7
   hash_length: 7
   name: openshift-probable-vulnerabilities
   environments:


### PR DESCRIPTION
Updated hash for the inference job so we can deploy sentry integration related code to prod environment.

Ref PRs : https://github.com/kubesecurity/openshift-probable-vulnerabilities/pull/42
Commit : https://github.com/kubesecurity/openshift-probable-vulnerabilities/commit/e245131c7e720b39f1af498740d10d5470228df7