### PR TITLE
OSA: Updated hash for api server and inference

### DIFF
--- a/bay-services/openshift-probable-vulnerabilities.yaml
+++ b/bay-services/openshift-probable-vulnerabilities.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: e245131c7e720b39f1af498740d10d5470228df7
+- hash: 27bdcc8f069c392b1fe194329ac8fe5feb682d33
   hash_length: 7
   name: openshift-probable-vulnerabilities
   environments:

--- a/bay-services/osa-api.yaml
+++ b/bay-services/osa-api.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 1dd79a69c78f600f8cd40bc624a7f6528d0f4116
+- hash: cf2c7b780af0e32a9c8159aab643ad6bdf2be6a5
   hash_length: 7
   name: osa-api-server
   environments:


### PR DESCRIPTION
Updated hash for the inference job  as well as osa api so we can deploy sentry integration related code to prod environment.

Ref PR: https://github.com/kubesecurity/osa-api-server/pull/20
Commit: https://github.com/kubesecurity/osa-api-server/commit/cf2c7b780af0e32a9c8159aab643ad6bdf2be6a5

Ref PR: https://github.com/kubesecurity/openshift-probable-vulnerabilities/pull/43
Commit: https://github.com/kubesecurity/openshift-probable-vulnerabilities/commit/27bdcc8f069c392b1fe194329ac8fe5feb682d33
