### PR TITLE
Sometimes Snyk feeds are not getting ingested.

### DIFF
--- a/bay-services/graph-cve-sync.yaml
+++ b/bay-services/graph-cve-sync.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 2a86089a40db728765537a6ad60a11c65df6d047
+- hash: 8c679f11a3892fed20f41ed4936a498c98aaad2b
   hash_length: 7
   name: graph-cve-sync
   environments:
@@ -11,7 +11,7 @@ services:
       CRON_SCHEDULE: "0 */6 * * *"
       SNYK_DELTA_FEED_MODE: true
       SNYK_INGESTION_FORCE_RUN: false
-      SNYK_DELTA_FEED_OFFSET: "1"
+      SNYK_DELTA_FEED_OFFSET: "7"
   - name: staging
     parameters:
       DOCKER_REGISTRY: quay.io
@@ -21,5 +21,6 @@ services:
       SNYK_DRY_RUN: true
       SNYK_DELTA_FEED_MODE: true
       DISABLE_SNYK_SYNC_OPERATION: false
+      SNYK_DELTA_FEED_OFFSET: "1"
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/graph-cve-sync


### PR DESCRIPTION
# Description
Fix for Snyk vulnerabilities are not being picked up sometimes for ingestion.

## Git PR
https://github.com/fabric8-analytics/graph-cve-sync/pull/42

## CentOS Build
https://ci.centos.org/job/devtools-graph-cve-sync-fabric8-analytics/73/