### PR TITLE
Reverting delta feed offset to 1 for prod.

### DIFF
--- a/bay-services/graph-cve-sync.yaml
+++ b/bay-services/graph-cve-sync.yaml
@@ -11,7 +11,7 @@ services:
       CRON_SCHEDULE: "0 */6 * * *"
       SNYK_DELTA_FEED_MODE: true
       SNYK_INGESTION_FORCE_RUN: false
-      SNYK_DELTA_FEED_OFFSET: "7"
+      SNYK_DELTA_FEED_OFFSET: "1"
   - name: staging
     parameters:
       DOCKER_REGISTRY: quay.io
@@ -21,6 +21,5 @@ services:
       SNYK_DRY_RUN: true
       SNYK_DELTA_FEED_MODE: true
       DISABLE_SNYK_SYNC_OPERATION: false
-      SNYK_DELTA_FEED_OFFSET: "1"
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/graph-cve-sync


### PR DESCRIPTION
# Description 

SNYK_DELTA_FEED_OFFSET was set to 7 on 24Aug (PR: https://github.com/openshiftio/saas-analytics/pull/863) for ingesting last 7 days of Snyk vulnerabilities into GraphDB. As the ingestion is done setting the offset value back to 1.
