### PR TITLE
chore: [gremlin] Enable JVM GC prints with date+time

### DIFF
--- a/bay-services/gremlin.yaml
+++ b/bay-services/gremlin.yaml
@@ -1,6 +1,6 @@
 services:
 - &gremlin_def
-  hash: 333989a30667382cc5ff418a13f324055dbc8448
+  hash: b7de11ecad717f8beb1d1d1b21f5cd85658f17e2
   hash_length: 7
   name: gremlin-http
   environments:

--- a/bay-services/gremlin.yaml
+++ b/bay-services/gremlin.yaml
@@ -15,7 +15,7 @@ services:
       CPU_LIMIT: 300m
       MEMORY_REQUEST: 1536Mi
       MEMORY_LIMIT: 2688Mi
-      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1400m"
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1400m -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
   - name: staging
     parameters:
       CHANNELIZER: http
@@ -27,7 +27,7 @@ services:
       MEMORY_LIMIT: 2688Mi
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
-      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1400m"
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1400m -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/
 
@@ -46,7 +46,7 @@ services:
       MEMORY_LIMIT: 2688Mi
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
-      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1024m"
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1400m -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
   - name: staging
     parameters:
       CHANNELIZER: http
@@ -59,6 +59,6 @@ services:
       MEMORY_LIMIT: 2688Mi
       DOCKER_REGISTRY: quay.io
       DOCKER_IMAGE: openshiftio/rhel-bayesian-gremlin
-      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1024m"
+      JAVA_OPTIONS: "-XX:+PrintFlagsFinal -Xms512m -Xmx1400m -XX:+PrintGCDetails -XX:+PrintGCDateStamps"
   path: /openshift/template.yaml
   url: https://github.com/fabric8-analytics/gremlin-docker/


### PR DESCRIPTION
Reference: https://blog.codecentric.de/en/2014/01/useful-jvm-flags-part-8-gc-logging/

E2E: https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/2681/