### PR TITLE
[backbone] Move v2 recommender refactoring to prod

### DIFF
--- a/bay-services/api-backbone.yaml
+++ b/bay-services/api-backbone.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 0dd5625a6338e4cc5faaad91d0f30d9e3a51fd6c
+- hash: 86b7c9bc62067ef9afc8a16c657ab0a409035793
   hash_length: 7
   name: api-backbone
   environments:


### PR DESCRIPTION
This PR rolls the following PRs to prod,

https://github.com/fabric8-analytics/f8a-server-backbone/pull/265
https://github.com/fabric8-analytics/f8a-server-backbone/pull/266
https://github.com/fabric8-analytics/f8a-server-backbone/pull/267
https://github.com/fabric8-analytics/f8a-server-backbone/pull/268
https://github.com/fabric8-analytics/f8a-server-backbone/pull/269

E2E: https://ci.centos.org/job/devtools-f8a-master-deploy-e2e-test/2740/