### PR TITLE
fix: Removing unused env variable.

### DIFF
--- a/bay-services/api.yaml
+++ b/bay-services/api.yaml
@@ -12,7 +12,6 @@ services:
       DOCKER_IMAGE: openshiftio/rhel-bayesian-bayesian-api
       METRICS_ACCUMULATOR_HOST: metrics-accumulator
       METRICS_ACCUMULATOR_PORT: 5200
-      DISABLE_UNKNOWN_PACKAGE_FLOW: 1
   - name: production
     parameters:
       FLASK_LOGGING_LEVEL: INFO


### PR DESCRIPTION
DISABLE_UNKNOWN_PACKAGE_FLOW env variables has been removed from fabric8-analytics-server/openshift/template.yaml, and it is no longer required in SAAS Analytics now.