### PR TITLE
[backbone] Move gunicorn preload and gevent changes to prod

### DIFF
--- a/bay-services/api-backbone.yaml
+++ b/bay-services/api-backbone.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 77dd14cbdab8503b29798b4d79976827437c69a7
+- hash: 18ff57d74c8875d8427295136e73139a04169390
   hash_length: 7
   name: api-backbone
   environments:


### PR DESCRIPTION
Includes following fixes from backbone,

https://github.com/fabric8-analytics/f8a-server-backbone/pull/273
https://github.com/fabric8-analytics/f8a-server-backbone/pull/274

diff: https://github.com/fabric8-analytics/f8a-server-backbone/compare/77dd14cbdab8503b29798b4d79976827437c69a7...18ff57d74c8875d8427295136e73139a04169390

latest e2e: https://ci.centos.org/job/devtools-f8a-server-backbone-f8a-build-master/