### PR TITLE
fix: Maven Central URL updated.

### DIFF
--- a/bay-services/jobs.yaml
+++ b/bay-services/jobs.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: 9a5010db96a212261e2feec887c96093dcd326b5
+- hash: 8a9d921e5ebb076acfc828f56b6e900dc6d1e9e6
   hash_length: 7
   name: jobs
   environments:


### PR DESCRIPTION
## CentOS build
https://ci.centos.org/job/devtools-fabric8-analytics-jobs-f8a-build-master/199/

## Git PR
https://github.com/fabric8-analytics/maven-index-checker/pull/8
https://github.com/fabric8-analytics/fabric8-analytics-jobs/pull/396