### PR TITLE
Revert "GH statistics collection." to retrigger deployment.

### DIFF
--- a/bay-services/worker.yaml
+++ b/bay-services/worker.yaml
@@ -1,7 +1,7 @@
 services:
 # INGESTION WORKERS
 - &worker_def
-  hash: f98ebb858e7383b06ae39163ef582b76373b06e3
+  hash: be5c02661f5b7c7ca8d1a07e9401c5824385e375
   hash_length: 7
   name: worker-ingestion
   environments:


### PR DESCRIPTION
Reverting the PR to retrigger the deployment job failed due to environment issues.
https://ci.centos.org/job/devtools-saas-analytics-promote-to-prod/842/