### PR TITLE
chore: Using auth free ingestion APIs.

### DIFF
--- a/bay-services/github-refresh-cronjob.yaml
+++ b/bay-services/github-refresh-cronjob.yaml
@@ -1,5 +1,5 @@
 services:
-- hash: bbe59fe70a29fd9bd4e720fce6be88e9928ad81b
+- hash: 6ee42e57507aaf5fda0e6849961ace2d5ad93d30
   hash_length: 7
   name: fabric8-analytics-github-refresh-cronjob
   environments:


### PR DESCRIPTION
# Description:
Use auth free Ingestion API to trigger github refresh flow into worker. Using head which is having CI related change as well.

# Git PR
https://github.com/fabric8-analytics/fabric8-analytics-github-refresh-cronjob/pull/51 

# CentOS build
https://ci.centos.org/job/devtools-fabric8-analytics-github-refresh-cronjob-build-master/33/

# Jira Ticket
https://issues.redhat.com/browse/APPAI-1715?filter=-2