### PR TITLE
fix: update stack report to have Snyk ID

### DIFF
--- a/bay-services/f8a-stacks-report.yaml
+++ b/bay-services/f8a-stacks-report.yaml
@@ -1,6 +1,6 @@
 services:
 - &stacks_def
-  hash: b96c76e2c712e47af92b51f21b4a6a5219b36579
+  hash: 4b179e2f50bbe9fb0cba8689e3d83ab353a7de37
   hash_length: 7
   name: stacks-report-daily
   environments:


### PR DESCRIPTION
This fix replaces CVE_ID with Snyk ID in Daily Venus Reporting

PR: https://github.com/fabric8-analytics/f8a-stacks-report/pull/198
Build: https://ci.centos.org/job/devtools-f8a-stacks-report-build-deploy-master/25/ 

Signed-off-by: Deepak Sharma <deepshar@redhat.com>