### PR TITLE
fix: Graph-cve-sync OOM error

### DIFF
--- a/bay-services/graph-cve-sync.yaml
+++ b/bay-services/graph-cve-sync.yaml
@@ -10,6 +10,10 @@ services:
       SYNC_MODE: diff #diff for differential sync and full for whole sync
       CRON_SCHEDULE: "0 */3 * * *"
       SNYK_DELTA_FEED_MODE: true
+      CPU_LIMIT: "750m"
+      CPU_REQUEST: "500m"
+      MEMORY_LIMIT: "2512Mi"
+      MEMORY_REQUEST: "2048Mi"
       SNYK_INGESTION_FORCE_RUN: false
       SNYK_CUSTOM_MODE: false
       SNYK_DELTA_FEED_OFFSET: "2"


### PR DESCRIPTION
This PR updates the resources that GraphCVE cronjob needs to run smoothly 